### PR TITLE
Fix vulnerable dependencies axios, xml2js and mocha to pass npm audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix vulnerable dependencies axios, xml2js and mocha to pass npm audit.
+
 ## 1.0.0 (2022-08-18)
 
 - Initial stable release. This supports importing sprite map files into Apostrophe to create individual SVG sprite pieces.

--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "mocha": "^7.2.0"
+    "mocha": "^10.4.0"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "axios": "^0.24.0",
+    "axios": "^1.6.8",
     "glob": "^7.2.0",
     "lodash": "^4.17.21",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.6.2"
   }
 }


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-5806/fix-the-apostrophecmssvg-sprite-vulnerability-so-that-were-not-scaring

https://linear.app/apostrophecms/issue/PRO-5807/apostrophecmssvg-sprite-depends-on-an-old-version-of-xml2js-which

Also did Mocha, as `npm audit` revealed a vulnerability.